### PR TITLE
fix for adding a 'similar' named search option

### DIFF
--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -73,6 +73,32 @@ router.use(
   })
 );
 
+router.use(
+  '/search/similar',
+  routeFactory.defaultSearchRoute({
+    authProvider: authProvider,
+    namedOptions: 'similar', // default: 'all'
+    // options: {
+    //   Add JSON search options here.
+    //   default: none
+    //   WARNING: This will override the saved search options referenced by 'namedOptions' above.
+    //   Example for making result labels using name property of person sample-data
+    //   'extract-document-data': {
+    //     'extract-path': ['/name']
+    //   }
+    // },
+    idConverter: idConverter, // default: encodeURIComponent(result.uri)
+    makeLabel: result => {
+      // default: none
+      return (
+        result.extracted &&
+        result.extracted.content[0] &&
+        result.extracted.content[0].name
+      );
+    }
+  })
+);
+
 // Provide CRUD route for pseudo-type 'all'
 router.use(
   '/crud/' + type,

--- a/routes/index.js
+++ b/routes/index.js
@@ -37,6 +37,16 @@ if (enableLegacyProxy) {
           endpoint: '/resources/extsimilar',
           methods: ['get'],
           authed: true
+        },
+        {
+          endpoint: '/values/*',
+          methods: ['get', 'post'],
+          authed: true
+        },
+        {
+          endpoint: '/config/query/all', // NOTE: allows get on all extensions
+          methods: ['get'],
+          authed: true
         }
         // TODO: move this to visjs documentation for visjs-graph
         // Other possibilities:


### PR DESCRIPTION
Required for migrating from a direct fetch to extsimilar to using a custom constraint to get 'similar' results. 