### PR TITLE
only allow tlsv1.2 with secure ciphers when using https

### DIFF
--- a/grove-node-server/node-server.js
+++ b/grove-node-server/node-server.js
@@ -5,6 +5,7 @@ var provider = (function() {
   var express = require('express');
   var helmet = require('helmet');
   var expressSession = require('express-session');
+  const { constants } = require('crypto');
 
   var provide = function(config) {
     var app = express();
@@ -73,6 +74,7 @@ var provider = (function() {
         'utf8'
       );
       var credentials = {
+        secureOptions: constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_TLSv1_1,
         key: privateKey,
         cert: certificate
       };


### PR DESCRIPTION
block tls v1 and v1.1 as per penetration tester review

https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls

97.29% of global browsers will support tls1.2 including IE11
https://caniuse.com/#feat=tls1-2