### PR TITLE
#15: Recognize xs: prefix as range facet type

### DIFF
--- a/grove-node-server-utils/filter.js
+++ b/grove-node-server-utils/filter.js
@@ -129,6 +129,9 @@ var filter = (function() {
 
   function constraint(type, name, operator, value) {
     type = type || 'range';
+    if (type.startsWith('xs:')) {
+      type = 'range';
+    }
     var c = queryBuilder.ext.constraint(type);
     if (type === 'range') {
       return c(name, operator, value);


### PR DESCRIPTION
Small fix necessary for using range filter (used by query builder amongst others)