### PR TITLE
Add ability to change the sort used in a search

### DIFF
--- a/grove-default-routes/search.js
+++ b/grove-default-routes/search.js
@@ -54,6 +54,16 @@ var provider = (function() {
         );
       }
 
+      if (options.sort) {
+        structuredQuery['and-query'].queries.push(
+          require('../grove-node-server-utils/query-builder-extensions').operatorState(
+            'sort',
+            options.sort
+          )
+        );
+        delete options.sort;
+      }
+
       return {
         search: {
           query: structuredQuery,

--- a/routes/index.js
+++ b/routes/index.js
@@ -40,14 +40,14 @@ if (enableLegacyProxy) {
           endpoint: '/resources/extsimilar',
           methods: ['get'],
           authed: true
-        }
+        },
         // TODO: move this to visjs documentation for visjs-graph
         // Other possibilities:
-        // {
-        //   endpoint: '/config/query/*',
-        //   methods: ['get'],
-        //   authed: true
-        // },
+        {
+          endpoint: '/config/query/*',
+          methods: ['get'],
+          authed: true
+        }
         // {
         //   endpoint: '/graphs/sparql',
         //   methods: ['get', 'post'],


### PR DESCRIPTION
Support adding the sort to the operator-state.

For now this does use the legacy /v1/config/query route.  I was not able to get the sample call using the defaultExtensionRoute (routes/api/index.js:65) to work; I kept getting a 405. 

Relates to "sibling" PRs:
https://github.com/marklogic-community/grove-core-react-components/pull/10
https://github.com/marklogic-community/grove-search-redux/pull/9
https://github.com/marklogic-community/grove-core-react-redux-containers/pull/10